### PR TITLE
Make Settings functions consistent.

### DIFF
--- a/src/CloudFlare/Zone/Settings.php
+++ b/src/CloudFlare/Zone/Settings.php
@@ -471,6 +471,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_minify($zone_identifier, $value) {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/minify', $value);
 
@@ -485,6 +487,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_mobile_redirect($zone_identifier, $value) {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/minify', $value);
 
@@ -499,6 +503,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_mirage($zone_identifier, $value = 'off') {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/mirage', $value);
 
@@ -513,6 +519,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_polish($zone_identifier, $value = 'off') {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/polish', $value);
 
@@ -527,6 +535,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_rocket_loader($zone_identifier, $value = 'off') {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/rocket_loader', $value);
 
@@ -541,6 +551,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_security_level($zone_identifier, $value = 'medium') {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/security_level', $value);
 
@@ -555,6 +567,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_server_side_exclude($zone_identifier, $value = 'on') {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/server_side_exclude', $value);
 
@@ -569,6 +583,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_ssl($zone_identifier, $value = 'off') {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/ssl', $value);
 
@@ -583,6 +599,8 @@ class Settings extends Api {
 	 * @return array|mixed
 	 */
 	public function change_waf($zone_identifier, $value = 'off') {
+		
+		$data = ['value' => $value];
 
 		return $this->patch('zones/' . $zone_identifier . '/settings/waf', $value);
 

--- a/src/CloudFlare/Zone/Settings.php
+++ b/src/CloudFlare/Zone/Settings.php
@@ -474,7 +474,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/minify', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/minify', $data);
 
 	}
 
@@ -490,7 +490,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/minify', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/minify', $data);
 
 	}
 
@@ -506,7 +506,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/mirage', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/mirage', $data);
 
 	}
 
@@ -522,7 +522,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/polish', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/polish', $data);
 
 	}
 
@@ -538,7 +538,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/rocket_loader', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/rocket_loader', $data);
 
 	}
 
@@ -554,7 +554,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/security_level', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/security_level', $data);
 
 	}
 
@@ -570,7 +570,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/server_side_exclude', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/server_side_exclude', $data);
 
 	}
 
@@ -586,7 +586,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/ssl', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/ssl', $data);
 
 	}
 
@@ -602,7 +602,7 @@ class Settings extends Api {
 		
 		$data = ['value' => $value];
 
-		return $this->patch('zones/' . $zone_identifier . '/settings/waf', $value);
+		return $this->patch('zones/' . $zone_identifier . '/settings/waf', $data);
 
 	}
 


### PR DESCRIPTION
Some of the settings functions would correctly set up `$value` into a key=>val array, but some did not. Just adding the ones that did not.
